### PR TITLE
Fix linux build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,11 +101,15 @@ jobs:
           printf '%s\n' "$BODY" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Set Ubuntu-specific environment variables
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          echo "LD_LIBRARY_PATH=/home/runner/work/kotonoha-asr/kotonoha-asr/src-tauri/target/release" >> $GITHUB_ENV
+          echo "RUSTFLAGS=-Clink-arg=-Wl,-rpath,\$ORIGIN" >> $GITHUB_ENV
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LD_LIBRARY_PATH: ${{ matrix.platform == 'ubuntu-22.04' && './src-tauri/target/release' || '' }}
-          RUSTFLAGS: ${{ matrix.platform == 'ubuntu-22.04' && '-Clink-arg=-Wl,-rpath,$ORIGIN' || '' }}
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: extract top section from CHANGELOG.md
         id: get_release_body
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
         run: |
           # If CHANGELOG.md exists, extract the top releasable section.
           # Behavior:
@@ -107,7 +109,7 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'
-          releaseBody: ${{ steps.get_release_body.outputs.body }}
+          releaseBody: ${{ matrix.platform == 'ubuntu-22.04' && steps.get_release_body.outputs.body || '' }}
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem
+# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem nreleased
 name: 'publish'
 
 on:
@@ -77,12 +77,12 @@ jobs:
                   state=1; print; next
                 } else { exit }
               }
-              if(state==1) print
+              state==1 { print }
             ' CHANGELOG.md)
 
             # If nothing captured (e.g. file has only Unreleased or different format), fall back to capturing the very first '## ' block
             if [ -z "$BODY" ]; then
-              BODY=$(awk 'BEGIN{found=0} /^##[[:space:]]/ { if(found==0){found=1; print; next} else {exit} } found{print}' CHANGELOG.md)
+              BODY=$(awk 'BEGIN{found=0} /^##[[:space:]]/ { if(found==0){found=1; print; next} else {exit} } found==1 { print }' CHANGELOG.md)
             fi
 
             # Final fallback to whole file if still empty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils file
 
       - name: setup node
         uses: actions/setup-node@v4
@@ -51,13 +51,54 @@ jobs:
       - name: install frontend dependencies
         run: npm install
 
+      - name: extract top section from CHANGELOG.md
+        id: get_release_body
+        run: |
+          # If CHANGELOG.md exists, extract the top releasable section.
+          # Behavior:
+          # - If the first '## ' is an Unreleased section, skip it and use the next '## ' block.
+          # - Otherwise use the first '## ' block.
+          if [ -f CHANGELOG.md ]; then
+            # Try: skip leading Unreleased and capture the following version block
+            BODY=$(awk '
+              BEGIN{state=0}
+              /^##[[:space:]]/ {
+                if(state==0) {
+                  if($0 ~ /[Uu]nreleased/) { state=2; next }
+                  else { state=1; print; next }
+                } else if(state==2) {
+                  state=1; print; next
+                } else { exit }
+              }
+              if(state==1) print
+            ' CHANGELOG.md)
+
+            # If nothing captured (e.g. file has only Unreleased or different format), fall back to capturing the very first '## ' block
+            if [ -z "$BODY" ]; then
+              BODY=$(awk 'BEGIN{found=0} /^##[[:space:]]/ { if(found==0){found=1; print; next} else {exit} } found{print}' CHANGELOG.md)
+            fi
+
+            # Final fallback to whole file if still empty
+            [ -z "$BODY" ] && BODY=$(cat CHANGELOG.md)
+          else
+            BODY="CHANGELOG.md not found in repository."
+          fi
+
+          # Trim leading/trailing blank lines
+          BODY="$(printf '%s\n' "$BODY" | sed '/^[[:space:]]*$/d')"
+
+          # Write multi-line output to GITHUB_OUTPUT
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          printf '%s\n' "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'
-          releaseBody: 'See the assets to download this version and install.'
-          releaseDraft: false
+          releaseBody: ${{ steps.get_release_body.outputs.body }}
+          releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore libwebkit libappindicator librsvg patchelf dtolnay swatinem
+# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem
 name: 'publish'
 
 on:
@@ -30,7 +30,14 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils file
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            xdg-utils \
+            file \
+            libclang-dev
 
       - name: setup node
         uses: actions/setup-node@v4
@@ -95,6 +102,8 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LD_LIBRARY_PATH: ${{ matrix.platform == 'ubuntu-22.04' && './src-tauri/target/release' || '' }}
+          RUSTFLAGS: ${{ matrix.platform == 'ubuntu-22.04' && '-Clink-arg=-Wl,-rpath,$ORIGIN' || '' }}
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem nreleased
+# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem nreleased RUSTFLAGS rpath
 name: 'publish'
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
             args: '--target universal-apple-darwin'
           - platform: 'ubuntu-22.04'
-            args: ''
+            args: '--verbose'
           - platform: 'windows-latest'
             args: ''
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 This section contains upcoming changes planned for the next release.
 
 - Fixed: HE‑AAC audio files without a file extension can now be imported and processed without error.
+- Fixed: Linux AppImage release
 
 ## v0.1.0 - 2025-08-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# This Dockerfile defines a build container for Linux (Ubuntu 22.04) to build and package the application.
+#
+# This Dockerfile is intended for local development only, and should be used by developers working on Linux.
+# Release builds are performed by GitHub Actions workflows; do not use this container for production releases.
+#
+# cSpell:ignore noninteractive ignore libwebkit libappindicator librsvg patchelf libclang onnxruntime libonnxruntime usermod
+
+FROM ubuntu:jammy-20250730
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    build-essential \
+    libwebkit2gtk-4.1-dev \
+    libappindicator3-dev \
+    librsvg2-dev \
+    patchelf \
+    ca-certificates \
+    git \
+    xdg-utils \
+    file \
+    libclang-dev
+
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y nodejs
+RUN npm install -g @tauri-apps/cli
+
+ARG UID=1000
+ARG GID=1000
+ARG USER_NAME=dev
+ARG GROUP_NAME=dev
+
+RUN if [ "$UID" -ne 0 ] && [ "$GID" -ne 0 ]; then \
+    groupadd -g ${GID} ${GROUP_NAME} && \
+    useradd -m -u ${UID} -g ${GID} ${USER_NAME}; \
+    fi
+
+USER ${USER_NAME}
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/home/${USER_NAME}/.cargo/bin:${PATH}"
+
+WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+# This docker-compose file is intended for local development only, specifically for Linux users.
+# Release builds are handled by GitHub Actions workflows; do not use this configuration for production releases.
+
+services:
+  linux-build:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      args:
+        - UID=${UID:-1000}
+        - GID=${GID:-1000}
+        - USER_NAME=${USER_NAME:-dev}
+        - GROUP_NAME=${GROUP_NAME:-dev}
+    volumes:
+      - .:/app
+    environment:
+      - UID=${UID}
+      - GID=${GID}
+      - LD_LIBRARY_PATH=/app/src-tauri/target/release
+      - RUSTFLAGS=-Clink-arg=-Wl,-rpath,$$ORIGIN
+    user: '${UID}:${GID}'
+    command: ["sh", "-c", "npm install && npm run build"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2268,7 +2268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sherpa-rs",
- "sherpa-rs-sys 0.6.6 (git+https://github.com/k5n/sherpa-rs)",
+ "sherpa-rs-sys",
  "symphonia",
  "tauri",
  "tauri-build",
@@ -4184,7 +4184,7 @@ source = "git+https://github.com/k5n/sherpa-rs?branch=timestamp-support-parakeet
 dependencies = [
  "eyre",
  "hound",
- "sherpa-rs-sys 0.6.6 (git+https://github.com/k5n/sherpa-rs?branch=timestamp-support-parakeet-tdt-0.6b-v2)",
+ "sherpa-rs-sys",
  "tracing",
 ]
 
@@ -4192,25 +4192,6 @@ dependencies = [
 name = "sherpa-rs-sys"
 version = "0.6.6"
 source = "git+https://github.com/k5n/sherpa-rs?branch=timestamp-support-parakeet-tdt-0.6b-v2#3b2da2d6853d3de6679a0c7b8e8de0b644ba166b"
-dependencies = [
- "bindgen",
- "bzip2",
- "cmake",
- "dirs 5.0.1",
- "flate2",
- "glob",
- "lazy_static",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "ureq",
-]
-
-[[package]]
-name = "sherpa-rs-sys"
-version = "0.6.6"
-source = "git+https://github.com/k5n/sherpa-rs#1f44a04f10ec8ef99a141411b49d5981d2893810"
 dependencies = [
  "bindgen",
  "bzip2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2268,7 +2268,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sherpa-rs",
- "sherpa-rs-sys",
  "symphonia",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,11 +24,11 @@ serde_json = "1"
 tauri-plugin-log = "2"
 log = "0.4"
 tauri-plugin-store = "2"
-sherpa-rs-sys = { git = "https://github.com/k5n/sherpa-rs" }
+sherpa-rs-sys = { git = "https://github.com/k5n/sherpa-rs", branch = "timestamp-support-parakeet-tdt-0.6b-v2" }
 sherpa-rs = { git = "https://github.com/k5n/sherpa-rs", branch = "timestamp-support-parakeet-tdt-0.6b-v2" }
 tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
 tauri-plugin-dialog = "2"
-symphonia = { version = "0.5.4", features= ["all"] }
+symphonia = { version = "0.5.4", features = ["all"] }
 rubato = "0.16.2"
 num_cpus = "1.17.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,8 +24,7 @@ serde_json = "1"
 tauri-plugin-log = "2"
 log = "0.4"
 tauri-plugin-store = "2"
-sherpa-rs-sys = { git = "https://github.com/k5n/sherpa-rs", branch = "timestamp-support-parakeet-tdt-0.6b-v2" }
-sherpa-rs = { git = "https://github.com/k5n/sherpa-rs", branch = "timestamp-support-parakeet-tdt-0.6b-v2" }
+sherpa-rs = { git = "https://github.com/k5n/sherpa-rs", branch = "timestamp-support-parakeet-tdt-0.6b-v2", features = ["download-binaries"] }
 tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION
This pull request introduces improvements to the Linux build and release process, focusing on developer experience and automation. It adds local development support via Docker, enhances the GitHub Actions workflow for publishing releases, and improves the release notes extraction from the changelog. The changes also update Linux dependencies and clarify the usage of certain build tools.

**Build and Release Process Improvements**

* Added a new `Dockerfile` and `docker-compose.yml` for local Linux development, allowing developers to build and package the application in a reproducible container environment. These are explicitly marked for local use only, not for production releases. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R45) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R22)
* Updated the GitHub Actions workflow (`.github/workflows/publish.yml`) to install additional dependencies (`xdg-utils`, `file`, `libclang-dev`) required for Linux builds and to improve dependency management.

**Release Automation and Changelog Handling**

* Implemented a workflow step to automatically extract the top section from `CHANGELOG.md` for use as the release body, skipping the "Unreleased" section when present and falling back gracefully if needed.
* Changed the release workflow to create draft releases by default and use the extracted changelog section as the release body, improving release documentation and review process.

**Dependency and Documentation Updates**

* Updated the `sherpa-rs-sys` and `sherpa-rs` dependencies in `src-tauri/Cargo.toml` to track a specific branch for timestamp support.
* Added a changelog entry for the Linux AppImage release, documenting the new platform support.