### PR TITLE
fix: bundle missing DLLs

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,9 @@
+{
+  "identifier": "com.k5-n.kotonoha.asr",
+  "bundle": {
+    "resources": {
+      "target/release/sherpa-onnx-c-api.dll": "./",
+      "target/release/onnxruntime.dll": "./"
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new configuration file for the Windows build of the Tauri application, specifying important resource bundling for required DLLs.

Windows build configuration:

* Added `src-tauri/tauri.windows.conf.json` to define the Windows application identifier and ensure that `sherpa-onnx-c-api.dll` and `onnxruntime.dll` are bundled with the app.