### PR TITLE
fix: Build issues on GitHub Actions workflow and local Docker environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem nreleased RUSTFLAGS rpath
+# cSpell:ignore libwebkit libappindicator librsvg patchelf libclang dtolnay swatinem nreleased RUSTFLAGS rpath esac
 name: 'publish'
 
 on:
@@ -16,11 +16,11 @@ jobs:
       matrix:
         include:
           - platform: 'macos-latest' # for Arm based macs (M1 and above).
-            args: '--target universal-apple-darwin'
+            args: '--target universal-apple-darwin --verbose'
           - platform: 'ubuntu-22.04'
             args: '--verbose'
           - platform: 'windows-latest'
-            args: ''
+            args: '--verbose'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -37,7 +37,9 @@ jobs:
             patchelf \
             xdg-utils \
             file \
-            libclang-dev
+            libclang-dev \
+            libssl-dev \
+            pkg-config
 
       - name: setup node
         uses: actions/setup-node@v4
@@ -55,51 +57,37 @@ jobs:
         with:
           workspaces: './src-tauri -> target'
 
-      - name: install frontend dependencies
-        run: npm install
-
-      - name: extract top section from CHANGELOG.md
-        id: get_release_body
-        if: matrix.platform == 'ubuntu-22.04'
+      # sherpa-rs がダウンロードを行うが、ビルド前に存在しないと macOS のビルドに失敗する。
+      # また他のプラットフォームでもビルド前に存在していた方が GitHub Actions でのビルドが安定する。
+      - name: Download and extract sherpa-onnx library
         shell: bash
         run: |
-          # If CHANGELOG.md exists, extract the top releasable section.
-          # Behavior:
-          # - If the first '## ' is an Unreleased section, skip it and use the next '## ' block.
-          # - Otherwise use the first '## ' block.
-          if [ -f CHANGELOG.md ]; then
-            # Try: skip leading Unreleased and capture the following version block
-            BODY=$(awk '
-              BEGIN{state=0}
-              /^##[[:space:]]/ {
-                if(state==0) {
-                  if($0 ~ /[Uu]nreleased/) { state=2; next }
-                  else { state=1; print; next }
-                } else if(state==2) {
-                  state=1; print; next
-                } else { exit }
-              }
-              state==1 { print }
-            ' CHANGELOG.md)
+          case "${{ matrix.platform }}" in
+            "macos-latest")
+              PACKAGE="sherpa-onnx-v1.11.5-osx-universal2-shared"
+              URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.11.5/$PACKAGE.tar.bz2"
+              ;;
+            "ubuntu-22.04")
+              PACKAGE="sherpa-onnx-v1.11.5-linux-x64-shared"
+              URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.11.5/$PACKAGE.tar.bz2"
+              ;;
+            "windows-latest")
+              PACKAGE="sherpa-onnx-v1.11.5-win-x64-shared"
+              URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.11.5/$PACKAGE.tar.bz2"
+              ;;
+          esac
 
-            # If nothing captured (e.g. file has only Unreleased or different format), fall back to capturing the very first '## ' block
-            if [ -z "$BODY" ]; then
-              BODY=$(awk 'BEGIN{found=0} /^##[[:space:]]/ { if(found==0){found=1; print; next} else {exit} } found==1 { print }' CHANGELOG.md)
-            fi
+          echo "Downloading from: $URL"
+          curl -L "$URL" -o "$PACKAGE.tar.bz2"
+          tar -xjf "$PACKAGE.tar.bz2"
+          rm "$PACKAGE.tar.bz2"
+          mkdir -p src-tauri/target/release
+          find "$PACKAGE/lib" -type f -exec cp {} src-tauri/target/release/ \;
+          rm -rf $PACKAGE
+          ls -la
 
-            # Final fallback to whole file if still empty
-            [ -z "$BODY" ] && BODY=$(cat CHANGELOG.md)
-          else
-            BODY="CHANGELOG.md not found in repository."
-          fi
-
-          # Trim leading/trailing blank lines
-          BODY="$(printf '%s\n' "$BODY" | sed '/^[[:space:]]*$/d')"
-
-          # Write multi-line output to GITHUB_OUTPUT
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          printf '%s\n' "$BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+      - name: install frontend dependencies
+        run: npm install
 
       - name: Set Ubuntu-specific environment variables
         if: matrix.platform == 'ubuntu-22.04'
@@ -110,10 +98,16 @@ jobs:
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHERPA_BUILD_SHARED_LIBS: 1
+          SHERPA_BUILD_DEBUG: 1
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'
-          releaseBody: ${{ matrix.platform == 'ubuntu-22.04' && steps.get_release_body.outputs.body || '' }}
+          releaseBody: |
+            See the assets to download this version and install.
+            - Linux: *_amd64.AppImage
+            - Windows: *_x64-setup.exe
+            - macOS: *_universal.app.tar.gz
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
     "AUTOINCREMENT",
     "cpus",
     "dotenvy",
+    "dylib",
     "flac",
     "flowbite",
     "kotonoha",

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update && \
     git \
     xdg-utils \
     file \
-    libclang-dev
+    libclang-dev \
+    libssl-dev \
+    pkg-config
 
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,12 @@
         "languages": ["English", "Japanese"],
         "displayLanguageSelector": true
       }
+    },
+    "macOS": {
+      "frameworks": [
+        "target/release/libsherpa-onnx-c-api.dylib",
+        "target/release/libonnxruntime.1.17.1.dylib"
+      ]
     }
   },
   "plugins": {


### PR DESCRIPTION
This pull request updates the build and release workflow for the project, focusing on improving stability and reliability of cross-platform builds, especially around the inclusion of the `sherpa-onnx` library. The changes also clarify release notes and ensure the necessary dependencies are installed for all platforms.

**Build process improvements:**

* Added a step to download and extract the appropriate `sherpa-onnx` shared library for each platform before building, ensuring consistent and stable builds on macOS, Linux, and Windows (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlL58-R90](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L58-R90)).
* Updated the macOS configuration in `tauri.conf.json` to explicitly include the required dynamic libraries in the build output (`src-tauri/tauri.conf.json`, [src-tauri/tauri.conf.jsonR49-R54](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7R49-R54)).

**Dependency management:**

* Added `libssl-dev` and `pkg-config` to the list of installed packages for both the GitHub Actions workflow and Dockerfile, preventing build failures due to missing dependencies (`.github/workflows/publish.yml`, [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L40-R42); `Dockerfile`, [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L24-R26).

**Release process updates:**

* Simplified and clarified the release body message to provide clear download instructions for each platform, replacing the previous logic that extracted release notes from `CHANGELOG.md` (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlR101-R110](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R101-R110)).

**Minor improvements:**

* Added `"dylib"` to the list of recognized words in VSCode settings to reduce spelling warnings during development (`.vscode/settings.json`, [.vscode/settings.jsonR45](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R45)).
* Increased verbosity for build commands to aid in debugging and troubleshooting (`.github/workflows/publish.yml`, [.github/workflows/publish.ymlL19-R23](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L19-R23)).