### PR TITLE
chore: update version to 0.1.1 and document changes in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 This section contains upcoming changes planned for the next release.
 
+## v0.1.0 - 2025-08-29
+
+- fix: Handling some abbreviations (like Mr.) correctly
+- fix: Remove redundant white spaces at the beginning of sentences
+
 ## v0.1.0 - 2025-08-28
 
 - Initial public release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kotonoha-asr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kotonoha-asr",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kotonoha-asr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kotonoha-ASR transcribes audio files into timestamped sentences using Automatic Speech Recognition (ASR) models.",
   "author": "Keigo Nakatani <k5n@users.noreply.github.com> (https://github.com/k5n)",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
This pull request includes a minor version bump and updates to the changelog to reflect recent bug fixes. The changes are straightforward and focus on improving sentence handling in transcriptions.

Release and changelog updates:

* Updated `package.json` to version `0.1.1` to reflect new fixes.
* Added changelog entries for fixing abbreviation handling (e.g., "Mr.") and removing redundant white spaces at the beginning of sentences in `CHANGELOG.md`.